### PR TITLE
fix(talk): deref pointer RequestType to prevent reflect panic on NumField

### DIFF
--- a/talk/extract/reflect.go
+++ b/talk/extract/reflect.go
@@ -130,7 +130,12 @@ func (e *ReflectExtractor) extractMethod(svcValue reflect.Value, method reflect.
 
 	// Extract request/response types
 	if methodType.NumIn() > 2 {
-		endpoint.RequestType = methodType.In(2)
+		reqType := methodType.In(2)
+		// Dereference pointer types so downstream code can safely call NumField etc.
+		if reqType.Kind() == reflect.Ptr {
+			reqType = reqType.Elem()
+		}
+		endpoint.RequestType = reqType
 	}
 	if methodType.NumOut() > 1 {
 		respType := methodType.Out(0)

--- a/talk/extractor.go
+++ b/talk/extractor.go
@@ -107,7 +107,12 @@ func (e *reflectExtractor) extractMethod(svcValue reflect.Value, method reflect.
 	}
 
 	if methodType.NumIn() > 2 {
-		endpoint.RequestType = methodType.In(2)
+		reqType := methodType.In(2)
+		// Dereference pointer types so downstream code can safely call NumField etc.
+		if reqType.Kind() == reflect.Ptr {
+			reqType = reqType.Elem()
+		}
+		endpoint.RequestType = reqType
 	}
 	if methodType.NumOut() > 1 {
 		respType := methodType.Out(0)

--- a/talk/transport/http/gin/server.go
+++ b/talk/transport/http/gin/server.go
@@ -298,10 +298,15 @@ func (s *Server) extractParams(c *gin.Context, ep *talk.Endpoint, req any) any {
 
 	// For struct types, use reflection to populate fields from path/query params
 	v := reflect.ValueOf(&req).Elem()
-	structVal := reflect.New(ep.RequestType).Elem()
+	// Dereference pointer types — ep.RequestType may be *SomeRequest from methodType.In(2)
+	reqType := ep.RequestType
+	if reqType.Kind() == reflect.Ptr {
+		reqType = reqType.Elem()
+	}
+	structVal := reflect.New(reqType).Elem()
 	structVal.Set(reflect.ValueOf(req))
 
-	t := ep.RequestType
+	t := reqType
 	changed := false
 
 	// Extract path parameters using `path` struct tag

--- a/talk/transport/http/std/server.go
+++ b/talk/transport/http/std/server.go
@@ -307,12 +307,17 @@ func (s *Server) extractParams(r *http.Request, ep *talk.Endpoint, req any) any 
 
 	// For struct types, use reflection to populate fields from path/query params
 	v := reflect.ValueOf(&req).Elem()
+	// Dereference pointer types — ep.RequestType may be *SomeRequest from methodType.In(2)
+	reqType := ep.RequestType
+	if reqType.Kind() == reflect.Ptr {
+		reqType = reqType.Elem()
+	}
 	// req is an interface{} holding a struct value; we need a pointer to modify it
-	structVal := reflect.New(ep.RequestType).Elem()
+	structVal := reflect.New(reqType).Elem()
 	// Copy existing values from req into structVal
 	structVal.Set(reflect.ValueOf(req))
 
-	t := ep.RequestType
+	t := reqType
 	changed := false
 
 	// Extract path parameters using `path` struct tag


### PR DESCRIPTION
Fixes #94

## Problem

When a service method uses a pointer request type:

```go
func (a *API) UpdateProduct(ctx context.Context, req *UpdateProductRequest) (*Product, error)
```

`methodType.In(2)` returns `*UpdateProductRequest` (pointer type). Downstream code in `extractParams` calls `t.NumField()` which panics on pointer types:

```
reflect: NumField of non-struct type *service.UpdateProductRequest
```

This affects all PUT/DELETE handlers with path parameters.

## Fix

1. **Root fix** in `extractor.go` and `extract/reflect.go`: dereference pointer types when setting `endpoint.RequestType`
2. **Defensive fix** in `std/server.go` and `gin/server.go`: dereference in `extractParams` as well

All existing tests pass.